### PR TITLE
fix: Sepolia RPC

### DIFF
--- a/frontend/constants/index.ts
+++ b/frontend/constants/index.ts
@@ -1,6 +1,7 @@
 export const contractAddress = `${process.env.NEXT_PUBLIC_CONTRACT_ADDRESS}` as `0x${string}`
 export const genesisBlock = `${process.env.NEXT_PUBLIC_GENESIS_BLOCK}`
 export const network = `${process.env.NEXT_PUBLIC_NETWORK}`
+export const httpTransport = `${process.env.NEXT_PUBLIC_HTTP_TRANSPORT}`
 export const abi = [
     {
         "inputs": [],

--- a/frontend/utils/index.ts
+++ b/frontend/utils/index.ts
@@ -1,6 +1,14 @@
-import { abi, contractAddress, genesisBlock, network} from "@/constants"
+import {abi, contractAddress, genesisBlock, httpTransport, network} from "@/constants"
 import { readContract, prepareWriteContract, writeContract } from "@wagmi/core"
-import { BaseError, ContractFunctionRevertedError, createPublicClient, GetLogsReturnType, http, parseAbiItem } from "viem"
+import {
+    BaseError,
+    ContractFunctionRevertedError,
+    createPublicClient,
+    GetLogsReturnType,
+    http,
+    HttpTransport,
+    parseAbiItem
+} from "viem"
 import { hardhat, sepolia } from "viem/chains"
 import {
     CompanyAccountUpdated,
@@ -28,9 +36,16 @@ const usedNetwork = () => {
     }
 }
 
+const useHttp = (): HttpTransport => {
+    switch (network) {
+        case 'sepolia': return http(httpTransport)
+        case 'hardhat': return http()
+        default: return http()
+    }
+}
 export const client = createPublicClient({
     chain: usedNetwork(),
-    transport: http()
+    transport: useHttp()
 })
 
 


### PR DESCRIPTION
- update the Sepolia rpc. The default one reach https://rpc.sepolia.org which has a very poor score (https://chainlist.org/chain/11155111?testnets=true)
- Use of https://endpoints.omniatech.io/v1/eth/sepolia/public